### PR TITLE
fix: inconsistent NodeJS and npm version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -36,8 +36,7 @@ RUN apt-get update \
 		git \
 		nodejs \
 		npm \
-		unzip \
-	&& npm install -g npm@latest
+		unzip
 
 # Set working directory to home
 WORKDIR /root


### PR DESCRIPTION
If we install latest npm, docker building will report errors:
```
#7 18.94 Scanning dependencies of target node_loader_bootstrap_depends
#7 19.12 ERROR: npm v9.6.2 is known not to run on Node.js v12.22.12. You'll need to
#7 19.12 upgrade to a newer Node.js version in order to use this version of npm. This
#7 19.12 version of npm supports the following node versions: `^14.17.0 || ^16.13.0 ||
#7 19.12 >=18.0.0`. You can find the latest version at https://nodejs.org/.
#7 19.12
#7 19.12 ERROR:
#7 19.12 /usr/local/lib/node_modules/npm/lib/utils/exit-handler.js:21
#7 19.12   const hasLoadedNpm = npm?.config.loaded
#7 19.12                            ^
#7 19.12
#7 19.12 SyntaxError: Unexpected token '.'
#7 19.12     at wrapSafe (internal/modules/cjs/loader.js:915:16)
#7 19.12     at Module._compile (internal/modules/cjs/loader.js:963:27)
#7 19.12     at Object.Module._extensions..js (internal/modules/cjs/loader.js:1027:10)
#7 19.12     at Module.load (internal/modules/cjs/loader.js:863:32)
#7 19.12     at Function.Module._load (internal/modules/cjs/loader.js:708:14)
#7 19.12     at Module.require (internal/modules/cjs/loader.js:887:19)
#7 19.12     at require (internal/modules/cjs/helpers.js:74:18)
#7 19.12     at module.exports (/usr/local/lib/node_modules/npm/lib/cli.js:81:23)
#7 19.12     at Object.<anonymous> (/usr/local/lib/node_modules/npm/bin/npm-cli.js:2:25)
#7 19.12     at Module._compile (internal/modules/cjs/loader.js:999:30)
#7 19.12 gmake[2]: *** [source/loaders/node_loader/bootstrap/CMakeFiles/node_loader_bootstrap_depends.dir/build.make:79: source/loaders/node_loader/bootstrap/CMakeFiles/node_loader_bootstrap_depends] Error 1
#7 19.12 gmake[1]: *** [CMakeFiles/Makefile2:1986: source/loaders/node_loader/bootstrap/CMakeFiles/node_loader_bootstrap_depends.dir/all] Error 2
#7 19.12 gmake: *** [Makefile:160: all] Error 2
```

And after removing upgrading:
```
Error: Invalid configuration file path (configurations/global.json)
Error: Invalid configuration file path (configurations/global.json)
30 + 20 = 50
```